### PR TITLE
Remove Compojure dependency

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,7 @@
   :license {:name "Apache License, Version 2.0"
             :url "http://www.apache.org/licenses/LICENSE-2.0.html"}
   :dependencies [[org.clojure/clojure "1.5.1"]
-                 [lib-noir "0.7.2"]
+                 [lib-noir "0.7.5"]
                  [enlive "1.1.4"]]
   :main forms-bootstrap.server
   :profiles {:dev {:dependencies [[compojure "1.1.5"]

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject paddleguru/forms-bootstrap "0.8.0"
+(defproject paddleguru/forms-bootstrap "0.8.0-SNAPSHOT"
   :description "Utility for creating web forms using Twitter's Bootstrap CSS"
   :url "https://github.com/paddleguru/forms-bootstrap"
   :license {:name "Apache License, Version 2.0"

--- a/project.clj
+++ b/project.clj
@@ -1,13 +1,13 @@
-(defproject paddleguru/forms-bootstrap "0.7.3"
+(defproject paddleguru/forms-bootstrap "0.8.0"
   :description "Utility for creating web forms using Twitter's Bootstrap CSS"
   :url "https://github.com/paddleguru/forms-bootstrap"
   :license {:name "Apache License, Version 2.0"
             :url "http://www.apache.org/licenses/LICENSE-2.0.html"}
   :dependencies [[org.clojure/clojure "1.5.1"]
                  [lib-noir "0.7.2"]
-                 [compojure "1.1.5"]
                  [enlive "1.1.4"]]
   :main forms-bootstrap.server
-  :profiles {:dev {:dependencies [[http-kit "2.1.13"]
+  :profiles {:dev {:dependencies [[compojure "1.1.5"]
+                                  [http-kit "2.1.13"]
                                   [ring/ring-core "1.2.0"]
                                   [org.clojure/data.json "0.2.1"]]}})

--- a/test/forms_bootstrap/server.clj
+++ b/test/forms_bootstrap/server.clj
@@ -1,5 +1,5 @@
 (ns forms-bootstrap.server
-  (:require [compojure.core :refer (GET)]
+  (:require [compojure.core :refer [GET POST]]
             [compojure.route :as route]
             [forms-bootstrap.core :as core]
             [forms-bootstrap.test.core :as c]
@@ -26,8 +26,8 @@
              [[(c/helper-example-user default-values (str "/" user "/action") "/")
                "Form-helper Example"
                "Uses the form-helper macro for easy validation."]]})))
-    c/helper-example-post
-    c/post-helper-example
+    (POST "/some-post-url" [] c/form-example-post)
+    (POST "/someaction" [] c/post-fn-example)
     (route/not-found "<p>Page not found.</p>")]))
 
 ;; Note that this library requires nm/app-handler to work, since we

--- a/test/forms_bootstrap/test/core.clj
+++ b/test/forms_bootstrap/test/core.clj
@@ -194,8 +194,7 @@
 
 ;; Post Helper Example
 (def post-fn-example
-  (c/post-fn :post-url "/someaction"
-             :validator (v/build-validator (v/non-empty-string :nickname))
+  (c/post-fn :validator (v/build-validator (v/non-empty-string :nickname))
              :on-success (fn [m]
                            ;;on success actions here
                            (println "Successful validation. Your form map: " m)
@@ -319,7 +318,6 @@
   :validator (v/build-validator (v/non-empty-string :first-name)
                                 (v/non-empty-string :last-name)
                                 (email-valid?))
-  :post-url "/:user/action"
   :submit-label "Sign Up!"
   :enctype "multipart/form-data"
   :fields [{:name "first-name"


### PR DESCRIPTION
And move the action outside.
- Renamed form-helper to defform
- Renamed post-helper to post-fn

This allows us to organize the actions in PaddleGuru using contexts. We couldn't do this before for these posts since the post url was buried inside the macro.

Once I removed that, post-helper doesn't have to be a macro anymore, which means that we won't have to cycle to fuck with these.
