### PR TITLE
Allow strings in defaults and errors map

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject paddleguru/forms-bootstrap "0.8.0"
+(defproject paddleguru/forms-bootstrap "0.8.1"
   :description "Utility for creating web forms using Twitter's Bootstrap CSS"
   :url "https://github.com/paddleguru/forms-bootstrap"
   :license {:name "Apache License, Version 2.0"

--- a/src/forms_bootstrap/core.clj
+++ b/src/forms_bootstrap/core.clj
@@ -589,15 +589,20 @@
         ;;on first load uses default data (ie from db), then POST DATA ONLY on a reload
         defaults (if (seq m)
                    (maybe-conj
-                    (map (fn[[k v]] {k {:errors nil :default (if (coll? v)
-                                                              (if (file-input? v)
-                                                                nil
-                                                                (map str v))
-                                                              (str v))}}) m))
+                    (map (fn [[k v]]
+                           (let [default (if (coll? v)
+                                           (when-not (file-input? v)
+                                             (map str v))
+                                           (str v))]
+                             {(keyword k) {:errors nil
+                                           :default default}}))
+                         m))
                    {})
         errors (if (seq flash-errors)
                  (maybe-conj
-                  (map (fn[[k v]] {k {:errors v :default ""}}) flash-errors))
+                  (map (fn [[k v]]
+                         {(keyword k) {:errors v :default ""}})
+                       flash-errors))
                  {})]
     (merge-with (fn [a b]
                   {:errors (:errors b)

--- a/src/forms_bootstrap/core.clj
+++ b/src/forms_bootstrap/core.clj
@@ -588,7 +588,8 @@
         m (if (seq flash-data)
             (dissoc flash-data :_sandbar-errors)
             default-values)
-        ;;on first load uses default data (ie from db), then POST DATA ONLY on a reload
+        ;;on first load uses default data (ie from db), then POST DATA
+        ;;ONLY on a reload
         defaults (if (seq m)
                    (maybe-conj
                     (map (fn [[k v]]

--- a/src/forms_bootstrap/core.clj
+++ b/src/forms_bootstrap/core.clj
@@ -213,8 +213,10 @@
 (defsnippet select-lite
   form-template
   [:div.select-dropdown :select]
-  [{:keys [name style class label inputs custom-inputs default type custom-attrs id div-attrs]}]
+  [{:keys [name style class label inputs custom-inputs default type custom-attrs id
+           div-attrs disabled]}]
   [:select] (do->
+             (maybe-disable disabled)
              (maybe-set-attrs (merge {:name name :id id :style style :class class}
                                      custom-attrs))
              (if (string-contains? type "multiple")


### PR DESCRIPTION
Otherwise, we can't use keys like "recipient[name]", since creating a keyword out of that and round tripping it through the session store causes a reader error (since the reader interprets `:recipient[name]` as a keyword followed by a vector).

I also added support for disabled select menus.
